### PR TITLE
Added Linux path find. Changed lang to C Sharp 11.

### DIFF
--- a/ResoniteModTemplate.csproj
+++ b/ResoniteModTemplate.csproj
@@ -4,11 +4,15 @@
     <TargetFramework>net472</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>preview</LangVersion>
+    <LangVersion>11</LangVersion>
   </PropertyGroup>
 
+  <!--This will test for the default Steam installation paths for Resonite on Windows and Linux.-->
+  <!--If you have Resonite installed in a non-default location, you can comment these out and manually define a path instead.-->
   <PropertyGroup Condition="'$(ResonitePath)'==''">
-    <ResonitePath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
+    <ResonitePath Condition="'$(OS)' == 'Windows_NT' and Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath> 
+    <ResonitePath Condition="'$(OS)' != 'Windows_NT' and Exists('$(HOME)/.local/share/Steam/steamapps/common/Resonite/')">$(HOME)/.local/share/Steam/steamapps/common/Resonite/</ResonitePath>
+    <!--<ResonitePath>/Uncomment/For/Custom/Resonite/Install-Path/Here/</ResonitePath>-->
   </PropertyGroup>
 
   <ItemGroup>

--- a/ResoniteModTemplate.csproj
+++ b/ResoniteModTemplate.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <!--This will test for the default Steam installation paths for Resonite on Windows and Linux.-->
-  <!--If you have Resonite installed in a non-default location, you can comment these out and manually define a path instead.-->
   <PropertyGroup Condition="'$(ResonitePath)'==''">
     <ResonitePath Condition="'$(OS)' == 'Windows_NT' and Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath> 
     <ResonitePath Condition="'$(OS)' != 'Windows_NT' and Exists('$(HOME)/.local/share/Steam/steamapps/common/Resonite/')">$(HOME)/.local/share/Steam/steamapps/common/Resonite/</ResonitePath>
-    <!--<ResonitePath>/Uncomment/For/Custom/Resonite/Install-Path/Here/</ResonitePath>-->
+    <!--If neither path above exists, you can define your custom Resonite install directory here -->
+    <ResonitePath Condition="'$(ResonitePath)'==''">/Custom/Resonite/Install/Path</ResonitePath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Small tweak to allow the CSProject file to automatically find required libraries if Resonite is installed in the default Steam directory on Linux in addition to Windows. Also a bit of commentary for those who have custom install directories elsewhere.

I also change the language version to C# 11 since we talked about the language version while working together with the template. Feel free to tweak this back to `preview` if you feel it's more appropriate for a template default.